### PR TITLE
Fix handling of errors

### DIFF
--- a/lib/crash.js
+++ b/lib/crash.js
@@ -1,0 +1,13 @@
+import { errors } from 'mobile-json-wire-protocol';
+
+
+function produceError () {
+  throw new errors.UnknownCommandError('Produced generic error for testing');
+}
+
+function produceCrash () {
+  throw new Error('We just tried to crash Appium!');
+}
+
+
+export { produceError, produceCrash };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,4 +1,5 @@
 import log from './logger';
+import { errors } from 'mobile-json-wire-protocol';
 
 
 function allowCrossDomain (req, res, next) {
@@ -29,12 +30,38 @@ function fixPythonContentType (req, res, next) {
   next();
 }
 
-function catchAllHandler (e, req, res, next) {
+function catchAllHandler (err, req, res, next) {
+  log.error(`Uncaught error: ${err.message}`);
+  log.error('Sending generic error response');
   try {
-    res.status(500).send(`Unknown server error! ${e.stack}`);
-    log.error(e);
-  } catch (e) {}
-  next(e);
+    res.status(500).send({
+      status: errors.UnknownError.code(),
+      value: `ERROR running Appium command: ${err.message}`
+    });
+    log.error(err);
+  } catch (ign) {
+    next(ign);
+  }
 }
 
-export { allowCrossDomain, fixPythonContentType, catchAllHandler };
+function catch4XXHandler (err, req, res, next) {
+  if (err.status >= 400 && err.status < 500) {
+    // set the content type to `text/plain`
+    // https://code.google.com/p/selenium/wiki/JsonWireProtocol#Responses
+    log.debug(`Setting content type to 'text/plain' for HTTP status '${err.status}'`);
+    res.set('Content-Type', 'text/plain');
+    res.status(err.status).send(`Unable to process request: ${err.message}`);
+  } else {
+    next(err);
+  }
+}
+
+function catch404Handler (req, res) {
+  // set the content type to `text/plain`
+  // https://code.google.com/p/selenium/wiki/JsonWireProtocol#Responses
+  log.debug('No route found. Setting content type to \'text/plain\'');
+  res.set('Content-Type', 'text/plain');
+  res.status(404).send(`The URL '${req.originalUrl}' did not map to a valid resource`);
+}
+
+export { allowCrossDomain, fixPythonContentType, catchAllHandler, catch404Handler, catch4XXHandler };

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,8 +6,10 @@ import bodyParser from 'body-parser';
 import methodOverride from 'method-override';
 import log from './logger';
 import { startLogFormatter, endLogFormatter } from './express-logging';
-import { allowCrossDomain, fixPythonContentType, catchAllHandler } from './middleware';
+import { allowCrossDomain, fixPythonContentType, catchAllHandler,
+         catch404Handler, catch4XXHandler } from './middleware';
 import { guineaPig, welcome, STATIC_DIR } from './static';
+import { produceError, produceCrash } from './crash';
 
 
 async function server (configureRoutes, port, hostname = 'localhost') {
@@ -49,11 +51,16 @@ function configureServer (app, configureRoutes) {
   app.use(favicon(path.resolve(STATIC_DIR, 'favicon.ico')));
   app.use(express.static(STATIC_DIR));
 
+  // crash routes, for testing
+  app.use('/wd/hub/produce_error', produceError);
+  app.use('/wd/hub/crash', produceCrash);
+
   // add middlewares
   app.use(allowCrossDomain);
   app.use(fixPythonContentType);
   app.use(bodyParser.urlencoded({extended: true}));
   app.use(methodOverride());
+  app.use(catch4XXHandler);
   app.use(catchAllHandler);
 
   // make sure appium never fails because of a file size upload limit
@@ -64,6 +71,9 @@ function configureServer (app, configureRoutes) {
   // dynamic routes for testing, etc.
   app.all('/welcome', welcome);
   app.all('/test/guinea-pig', guineaPig);
+
+  // catch this last, so anything that falls through is 404ed
+  app.use(catch404Handler);
 }
 
 export { server, configureServer };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.13.3",
     "lodash": "^3.10.1",
     "method-override": "^2.3.5",
+    "mobile-json-wire-protocol": "^1.0.2",
     "morgan": "^1.6.1",
     "serve-favicon": "^2.3.0",
     "source-map-support": "^0.3.2",

--- a/test/server-specs.js
+++ b/test/server-specs.js
@@ -16,7 +16,7 @@ describe('server configuration', () => {
     let app = {use: sinon.spy(), all: sinon.spy()};
     let configureRoutes = () => {};
     configureServer(app, configureRoutes);
-    app.use.callCount.should.equal(10);
+    app.use.callCount.should.equal(14);
     app.all.callCount.should.equal(2);
   });
 


### PR DESCRIPTION
The spec says we need `text/plain` context type for 4xx errors (https://code.google.com/p/selenium/wiki/JsonWireProtocol#Responses). They also need to have special handling of their message.
