### PR TITLE
Fix static files folder in Windows

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 
 let STATIC_DIR = path.resolve(__dirname, '..', '..', 'static');
-if (_.isNull(path.resolve(__dirname).match(/build\/lib$/))) {
+if (_.isNull(path.resolve(__dirname).match(/build[\/\\]lib$/))) {
   // in some contexts we are not in the build directory,
   // so we don't want to go back the extra level
   STATIC_DIR = path.resolve(__dirname, '..', 'static');


### PR DESCRIPTION
Appium 1.5 does not start in Windows and displays the error:

```
Error: ENOENT: no such file or directory, stat 'D:\appium\node_modules\appium-express\build\static\favicon.ico'
    at Error (native)
    at Object.fs.statSync (fs.js:849:18)
    at favicon (D:\appium\node_modules\appium-express\node_modules\serve-favicon\index.js:64:15)
    at configureServer (lib/server.js:51:11)
    at lib/server.js:35:5
```

Now the 'if' statement checks if STATIC_DIR ends with 'build/lib' or 'build\lib'.
